### PR TITLE
feat: 홈 api 기능& 메이트 프로필prop과 타입 수정 #27

### DIFF
--- a/front/app/(route)/home/components/MateList.tsx
+++ b/front/app/(route)/home/components/MateList.tsx
@@ -3,13 +3,16 @@ import MateProfile from '../../../components/profile/MateProfile';
 import { IMate } from '@/app/_types';
 import styled from 'styled-components';
 import Image from 'next/image';
+import { IHomeData } from '@/app/_types/user/Mate';
 
-interface IMateHomeProps {
+
+interface IMateListProps {
   mates: IMate[];
 }
 
-const MateList = ({ mates }: IMateHomeProps) => {
+const MateList = ({ mates }: IMateListProps) => {
   const [isEdit, setIsedit] = useState(false);
+  console.log('mates data', mates)
 
   const onEditClick = () => {
     setIsedit(!isEdit);
@@ -24,7 +27,7 @@ const MateList = ({ mates }: IMateHomeProps) => {
 
       <ProfileWrapper>
         {mates?.map((mate) => <MateProfile key={mate.userId} mate={mate} size='60' />)}
-        <PlusWrapper>{mates.length < 4 && <Image src={'/svgs/mate_plus.svg'} alt='mate-edit-btn' width={24} height={24} />}</PlusWrapper>
+        <PlusWrapper>{mates?.length < 4 && <Image src={'/svgs/mate_plus.svg'} alt='mate-edit-btn' width={24} height={24} />}</PlusWrapper>
       </ProfileWrapper>
     </Wrapper>
   );

--- a/front/app/(route)/home/components/ReportCard.tsx
+++ b/front/app/(route)/home/components/ReportCard.tsx
@@ -3,31 +3,25 @@ import styled from 'styled-components'
 import PetsIcon from '@mui/icons-material/Pets';
 import dayjs from 'dayjs';
 import Image from 'next/image';
+import { IReport } from '@/app/_types/user/Mate';
 
-
-interface IDummyData {
-    today_poo_cnt: number,
-    last_week_walk_cnt: number,
-    last_wash_date: string,
-    last_hospital_date: string,
-}
 
 interface IReportCard {
-    dummyReports: IDummyData
-
+    reports: IReport;
+    userName: string;
 }
 
-const ReportCard = ({ dummyReports }: IReportCard) => {
+const ReportCard = ({ reports, userName }: IReportCard) => {
     const reportsArray = [
-        { title: '오늘의 배변활동', count: dummyReports.today_poo_cnt, unit: '회', icon: <Image src={'/svgs/poop.svg'} alt="배변활동 아이콘" width={30} height={30} /> },
-        { title: '지난주 산책', count: dummyReports.last_week_walk_cnt, unit: '회', icon: <Image src={'/svgs/paw.svg'} alt="산책 아이콘" width={25} height={25} /> },
-        { title: '마지막 목욕', count: dayjs(dummyReports.last_wash_date).format('MM.DD'), icon: <Image src={'/svgs/dog_bath.svg'} alt="마지막 목욕 아이콘" width={30} height={30} /> },
-        { title: '마지막 검진', count: dayjs(dummyReports.last_hospital_date).format('MM.DD'), icon: <Image src={'/svgs/dog_health_check.svg'} alt="마지막 검진 아이콘" width={30} height={30} /> },
+        { title: '오늘의 배변활동', count: reports.todayPooCount, unit: '회', icon: <Image src={'/svgs/poop.svg'} alt="배변활동 아이콘" width={30} height={30} /> },
+        { title: '지난주 산책', count: reports.lastWalkCount, unit: '회', icon: <Image src={'/svgs/paw.svg'} alt="산책 아이콘" width={25} height={25} /> },
+        { title: '마지막 목욕', count: reports.lastWash ? dayjs(reports.lastWash).format('MM.DD') : '-', icon: <Image src={'/svgs/dog_bath.svg'} alt="마지막 목욕 아이콘" width={30} height={30} /> },
+        { title: '마지막 검진', count: reports.lastHospitalDate ? dayjs(reports.lastHospitalDate).format('MM.DD') : '-', icon: <Image src={'/svgs/dog_health_check.svg'} alt="마지막 검진 아이콘" width={30} height={30} /> },
     ];
     return (
         <>
             <ReportCardWrapper>
-                <Title>멍순이 리포트</Title>
+                <Title>{userName}의 리포트</Title>
 
                 {reportsArray.map((report, index) => (
                     <Wrapper key={index}>

--- a/front/app/(route)/home/components/UserProfile.tsx
+++ b/front/app/(route)/home/components/UserProfile.tsx
@@ -1,28 +1,30 @@
+import { IDogDetail } from '@/app/_types/user/Mate';
+import dayjs from 'dayjs';
 import Image from 'next/image'
 import { useRouter } from 'next/navigation';
 import React from 'react'
 import styled from 'styled-components';
 
-export interface IUserProfileProps {
-  user?: {
-    profileImg?: string;
-  };
+interface UserProfileProps {
+  user: IDogDetail;
 }
 
-const UserProfile = ({ user }: IUserProfileProps) => {
+const UserProfile = ({ user }: UserProfileProps) => {
   const router = useRouter();
+  const formattedBirthday = dayjs(user.birthday).format('YYYY.MM.DD');
+
   return (
     <Wrapper>
       <ImageWrapper>
-        {user && user.profileImg ? (
+        {user && user.imgUrl ? (
           <>
-            <Image
-              src={user.profileImg}
+            {/* <Image
+              src={user.imgUrl}
               alt="User Profile"
               layout="fill"
               objectFit="cover"
               objectPosition="center"
-            />
+            /> */}
 
           </>
         ) : (
@@ -38,15 +40,15 @@ const UserProfile = ({ user }: IUserProfileProps) => {
         )}
       </ImageWrapper>
       <UserInfo>
-        <p>멍순이</p>
+        <p>{user.name}</p>
         <div>
-          <span>성별</span> 여자
+          <span>성별</span> {user.gender === 'FEMALE' ? '여자' : '남자'}
         </div>
         <div>
-          <span>생일</span> 22.10.23
+          <span>생일</span> {formattedBirthday}
         </div>
         <div>
-          <span>체중</span> 4.3 kg
+          <span>체중</span> {user.weight} kg
         </div>
       </UserInfo>
       <EditBtn onClick={() => router.push('profile/dog')}>

--- a/front/app/(route)/home/components/WalkRank.tsx
+++ b/front/app/(route)/home/components/WalkRank.tsx
@@ -1,3 +1,4 @@
+import { IRanking } from '@/app/_types/user/Mate';
 import Image from 'next/image';
 import React from 'react';
 import styled from 'styled-components';
@@ -10,7 +11,7 @@ interface IUser {
 }
 
 interface IWalkRank {
-  ranking: IUser[];
+  ranking: IRanking[];
 }
 
 
@@ -22,13 +23,13 @@ const WalkRank = ({ ranking }: IWalkRank) => {
         <ChartWrapper>
           {ranking?.map((user, index) => (
             <BoxWrapper key={index}>
-              <UserContainer walkCount={user.rank}>
-                {user.user_img ? <UserProfileImage><Image src={user.user_img} alt='프로필 이미지' width={65} height={65} /></UserProfileImage>
-                  : <UserProfileImage />}
-                <Nickname>{user.nickname}</Nickname>
-                <WalkCount>{user.rank}회</WalkCount>
+              <UserContainer walkCount={user.count}>
+                {/* {user.imgUrl ? <UserProfileImage><Image src={user.imgUrl} alt='프로필 이미지' width={65} height={65} /></UserProfileImage>
+                  : <UserProfileImage />} */}
+                <Nickname>{user.nickName}</Nickname>
+                <WalkCount>{user.count}회</WalkCount>
               </UserContainer>
-              <Bar walkCount={user.rank} />
+              <Bar walkCount={user.count} />
             </BoxWrapper>
           ))}
         </ChartWrapper>

--- a/front/app/(route)/home/page.tsx
+++ b/front/app/(route)/home/page.tsx
@@ -12,6 +12,7 @@ import { useEffect } from 'react';
 import axios from 'axios';
 import { useQuery } from 'react-query';
 import instance from '@/app/_utils/apis/interceptors';
+import { IHomeData, IMate, IRanking, IReport } from '@/app/_types/user/Mate';
 
 const dummyMatesData = [
   {
@@ -62,10 +63,10 @@ const dummyRanking = [
   },
 ];
 
-const fetchHomeData = async () => {
+const fetchHomeData = async (): Promise<IHomeData> => {
   try {
-    const response = await instance.put('/api/home/');
-    return response.data;
+    const response = await instance.get('/api/home');
+    return response.data.data;
   } catch (error) {
     throw new Error('Home api 페칭 에러');
   }
@@ -73,7 +74,8 @@ const fetchHomeData = async () => {
 
 const Page = () => {
   const router = useRouter();
-  const { data, isLoading, isError } = useQuery('homeData', fetchHomeData);
+  const { data, isLoading, isError } = useQuery<IHomeData>('homeData', fetchHomeData);
+  console.log('home data:', data)
 
   useEffect(() => {
     const accessToken = localStorage.getItem('access_token');
@@ -82,13 +84,18 @@ const Page = () => {
     }
   }, []);
 
+  const mates: IMate[] = data?.mateDto || [];
+  console.log('mates 데이터', mates)
+  // const reports: IReport = data?.reportDto || dummyReports;
+  // const ranking: IRanking[] = data?.rankingDto || dummyRanking;
+
   return (
     <main>
       <ContainerLayout>
         <TopNavigation />
         <Wrapper>
           <UserProfile />
-          <MateList mates={dummyMatesData} />
+          <MateList mates={mates} />
           <ReportCard dummyReports={dummyReports} />
           <WalkRank ranking={dummyRanking} />
         </Wrapper>

--- a/front/app/(route)/home/page.tsx
+++ b/front/app/(route)/home/page.tsx
@@ -12,28 +12,8 @@ import { useEffect } from 'react';
 import axios from 'axios';
 import { useQuery } from 'react-query';
 import instance from '@/app/_utils/apis/interceptors';
-import { IHomeData, IMate, IRanking, IReport } from '@/app/_types/user/Mate';
+import { IDogDetail, IHomeData, IMate, IRanking, IReport } from '@/app/_types/user/Mate';
 
-const dummyMatesData = [
-  {
-    user_id: '2222',
-    user_img: 'image_url',
-    nickname: '파파',
-    role: '아빠',
-  },
-  {
-    user_id: '3333',
-    user_img: 'image_url',
-    nickname: '브라더',
-    role: '형',
-  },
-  {
-    user_id: '3333',
-    user_img: 'image_url',
-    nickname: '브라더',
-    role: '형',
-  },
-];
 
 const dummyReports = {
   today_poo_cnt: 2,
@@ -85,19 +65,40 @@ const Page = () => {
   }, []);
 
   const mates: IMate[] = data?.mateDto || [];
-  console.log('mates 데이터', mates)
-  // const reports: IReport = data?.reportDto || dummyReports;
-  // const ranking: IRanking[] = data?.rankingDto || dummyRanking;
+  const user: IDogDetail = data?.dogDetailResponse || {
+    dogId: 0,
+    name: '',
+    weight: 0,
+    gender: 'FEMALE',
+    birthday: '',
+    imgUrl: 'src://',
+  };
+
+  console.log('mates 데이터', mates);
+
+  const reports: IReport = data?.reportDto || {
+    todayPooCount: 0,
+    lastWalkCount: 0,
+    lastWash: '',
+    lastHospitalDate: '',
+  };
+  const ranking: IRanking[] = data?.rankingDto || [{
+    userId: 0,
+    imgUrl: 'src://',
+    nickName: '',
+    userRole: '',
+    count: 0,
+  }];
 
   return (
     <main>
       <ContainerLayout>
         <TopNavigation />
         <Wrapper>
-          <UserProfile />
+          <UserProfile user={user} />
           <MateList mates={mates} />
-          <ReportCard dummyReports={dummyReports} />
-          <WalkRank ranking={dummyRanking} />
+          <ReportCard reports={reports} userName={user.name} />
+          <WalkRank ranking={ranking} />
         </Wrapper>
         <BottomNavigation />
       </ContainerLayout>

--- a/front/app/(route)/setting/page.tsx
+++ b/front/app/(route)/setting/page.tsx
@@ -36,26 +36,12 @@ interface UserState {
 }
 
 const page = () => {
-<<<<<<< api/userProfileMod
-    const [isToggled, setIsToggled] = useState(false);
-    const [isLogoutModal, setLogoutIsModal] = useState(false);
-    const [isTerminateModal, setTerminateModal] = useState(false);
-    const queryClient = useQueryClient();
-    const router = useRouter();
-    const accessToken = localStorage.getItem('access_token');
-=======
   const [isToggled, setIsToggled] = useState(false);
   const [isLogoutModal, setLogoutIsModal] = useState(false);
   const [isTerminateModal, setTerminateModal] = useState(false);
-  const [accessToken, setAccessToken] = useState<string | null>(null);
   const queryClient = useQueryClient();
   const router = useRouter();
-
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      setAccessToken(localStorage.getItem(LOCAL_STORAGE_KEYS.ACCESS_TOKEN));
-    }
-  }, []);
+  const accessToken = localStorage.getItem('access_token');
 
   const { mutate: notification } = useMutation((active: boolean) => fetchNotification(active, accessToken), {
     onSuccess: () => {
@@ -63,19 +49,18 @@ const page = () => {
     },
   });
 
-  //알림 토글 함수
+  // 알림 토글 함수
   const handelToggle = (toggled: boolean) => {
     setIsToggled(toggled);
     notification(toggled);
   };
 
-  //매이트 초대 함수(/invite로 라우팅)
+  // 매이트 초대 함수(/invite로 라우팅)
   const handleMateInvite = () => {
     if (typeof window !== 'undefined') {
       router.push('/invite');
     }
   };
->>>>>>> dev-front
 
   const toggleLogoutModal = () => {
     setLogoutIsModal(!isLogoutModal);
@@ -85,100 +70,19 @@ const page = () => {
     setTerminateModal(!isTerminateModal);
   };
 
-  //로그아웃
+  // 로그아웃
   const { mutate: logoutMutation } = useLogout();
 
-  //회원탈퇴
+  const handleLogout = () => {
+    logoutMutation({ accessToken });
+  };
+
+  // 회원탈퇴
   const { mutate: terminateMutation } = useTerminateAccount();
 
-  const handleLogout = () => {
-    if (accessToken) {
-      logoutMutation(
-        { accessToken },
-        {
-          onSuccess: () => {
-            if (typeof window !== 'undefined') {
-              router.push('/auth/login');
-            }
-          },
-        },
-      );
-    }
-  };
-
   const handleTerminate = () => {
-    if (accessToken) {
-      terminateMutation({ accessToken });
-    }
+    terminateMutation({ accessToken });
   };
-
-<<<<<<< api/userProfileMod
-    //로그아웃
-    const { mutate: logoutMutation } = useLogout();
-
-    const handleLogout = () => {
-        logoutMutation({ accessToken });
-    }
-
-    //회원탈퇴
-    const { mutate: terminateMutation } = useTerminateAccount();
-
-    //회원 탈퇴 
-    const handleTerminate = () => {
-        terminateMutation({ accessToken })
-    };
-
-
-    return (
-        <>
-            <TopNavigation />
-            <Wrapper>
-                <UpperUserProfile user={UserDummy} />
-                <MenuWrapper>
-                    <NavMenu title='알림 설정' >
-                        <ToggleSwitch onToggle={handelToggle} isToggled={isToggled} />
-                    </NavMenu>
-                    <NavMenu title='로그아웃' onClick={toggleLogoutModal} />
-                    {isLogoutModal && (
-                        <Modal
-                            children="로그아웃하시겠습니까?"
-                            btn1="취소"
-                            btn2="로그아웃"
-                            onClose={toggleLogoutModal}
-                            onBtn2Click={handleLogout}
-
-                        />
-                    )}
-                    <NavMenu title='회원 탈퇴' onClick={toggleTerminateModal} />
-                    {isTerminateModal && (
-                        <Modal
-                            children="정말 탈퇴 하시겠습니까?"
-                            btn1="취소"
-                            btn2="회원 탈퇴"
-                            onClose={toggleTerminateModal}
-                            onBtn2Click={handleTerminate}
-                        />
-                    )}
-                    <NavMenu title='메이트 초대하기' onClick={handleMateInvite} />
-                </MenuWrapper>
-            </Wrapper>
-            <BottomNavigation />
-        </>
-    )
-}
-=======
-  useEffect(() => {
-    if (isLogoutModal) {
-      handleLogout();
-    }
-  }, [isLogoutModal]);
->>>>>>> dev-front
-
-  useEffect(() => {
-    if (isTerminateModal) {
-      handleTerminate();
-    }
-  }, [isTerminateModal]);
 
   return (
     <>
@@ -190,9 +94,25 @@ const page = () => {
             <ToggleSwitch onToggle={handelToggle} isToggled={isToggled} />
           </NavMenu>
           <NavMenu title='로그아웃' onClick={toggleLogoutModal} />
-          {isLogoutModal && <Modal children='로그아웃하시겠습니까?' btn1='취소' btn2='로그아웃' onClose={toggleLogoutModal} />}
+          {isLogoutModal && (
+            <Modal
+              children='로그아웃하시겠습니까?'
+              btn1='취소'
+              btn2='로그아웃'
+              onClose={toggleLogoutModal}
+              onBtn2Click={handleLogout}
+            />
+          )}
           <NavMenu title='회원 탈퇴' onClick={toggleTerminateModal} />
-          {isTerminateModal && <Modal children='정말 탈퇴 하시겠습니까?' btn1='취소' btn2='회원 탈퇴' onClose={toggleTerminateModal} onBtn2Click={handleTerminate} />}
+          {isTerminateModal && (
+            <Modal
+              children='정말 탈퇴 하시겠습니까?'
+              btn1='취소'
+              btn2='회원 탈퇴'
+              onClose={toggleTerminateModal}
+              onBtn2Click={handleTerminate}
+            />
+          )}
           <NavMenu title='메이트 초대하기' onClick={handleMateInvite} />
         </MenuWrapper>
       </Wrapper>
@@ -214,4 +134,5 @@ const Wrapper = styled.div`
   align-items: center;
   margin-top: 50px;
 `;
+
 export default page;

--- a/front/app/_types/schedule/Schedule.ts
+++ b/front/app/_types/schedule/Schedule.ts
@@ -1,13 +1,16 @@
 export interface IScheduleItem {
   scheduleId: number;
   scheduleType: string;
-  mates: {
-    userId: number;
-    user_img: string;
-  }[];
+  mates: number[];
   scheduleDate?: string;
-  reservedDate?: string;
   time: string;
   repeatId?: string | null;
   active: boolean;
+  alertType: string;
+  homeId: string;
+  isActive: boolean;
+  isDeleted: boolean;
+  memo: string;
+  repeatType: string;
+  scheduleTime: string;
 }

--- a/front/app/_types/user/Mate.ts
+++ b/front/app/_types/user/Mate.ts
@@ -1,6 +1,37 @@
+export interface IHomeData {
+  dogDetailResponse: IDogDetail;
+  mateDto: IMate[];
+  rankingDto: IRanking[];
+  reportDto: IReport;
+}
+
+
+export interface IDogDetail {
+  dogId: number;
+  name: string;
+  weight: number;
+  gender: 'FEMALE' | 'MALE';
+  birthday: string;
+}
+
 export interface IMate {
   userId: number;
-  user_img?: string;
-  nickname?: string;
-  role?: string;
+  imgUrl?: string;
+  nickName?: string;
+  userRole?: string;
+}
+
+export interface IRanking {
+  userId: number;
+  imgUrl: string;
+  nickName: string;
+  userRole: string;
+  count: number;
+}
+
+export interface IReport {
+  todayPooCount: number;
+  lastWalkCount: number;
+  lastWash: string | null;
+  lastHospitalDate: string | null;
 }

--- a/front/app/_types/user/Mate.ts
+++ b/front/app/_types/user/Mate.ts
@@ -12,6 +12,7 @@ export interface IDogDetail {
   weight: number;
   gender: 'FEMALE' | 'MALE';
   birthday: string;
+  imgUrl: string;
 }
 
 export interface IMate {

--- a/front/app/components/card/TodoCard.tsx
+++ b/front/app/components/card/TodoCard.tsx
@@ -9,14 +9,19 @@ interface ITodoCardProps {
 
 const TodoCard = ({ todoList }: ITodoCardProps) => {
   const [todos, setTodos] = useState(todoList);
+  console.log('todos다!!!!', todos)
 
   const handleCheckboxChange = (scheduleId: number) => {
-    const updatedTodos = todos.map((todo) => (todo.scheduleId === scheduleId ? { ...todo, active: !todo.active } : todo));
+    const updatedTodos = todos.map((todo) => (todo.scheduleId === scheduleId ? { ...todo, active: !todo.isActive } : todo));
+    console.log('updatedTodos입니다', updatedTodos)
     setTodos(updatedTodos);
   };
 
-  const activeTodos = todos.filter((todo) => todo.active);
-  const inactiveTodos = todos.filter((todo) => !todo.active);
+  const activeTodos = todoList.filter((todo) => todo.isActive);
+  console.log('액티브', activeTodos)
+  const inactiveTodos = todoList.filter((todo) => !todo.isActive);
+  console.log('인액티브', inactiveTodos)
+
 
   return (
     <Wrapper>
@@ -55,7 +60,7 @@ const TodoCard = ({ todoList }: ITodoCardProps) => {
       )}
 
       <RegisteredMate></RegisteredMate>
-      {activeTodos.length === 0 && inactiveTodos.length === 0 && <CenteredMessage>일정을 추가해주세요!</CenteredMessage>}
+      {activeTodos.length === 0 && inactiveTodos.length === 0 && <CenteredMessage>일정이 없습니다.</CenteredMessage>}
     </Wrapper>
   );
 };
@@ -147,7 +152,7 @@ const MateImgWrapper = styled.div`
   position: relative;
 `;
 
-const MateImg = styled(Image)<{ index: number }>`
+const MateImg = styled(Image) <{ index: number }>`
   width: 25px;
   height: 25px;
   border-radius: 50%;

--- a/front/app/components/card/TodoCard.tsx
+++ b/front/app/components/card/TodoCard.tsx
@@ -9,7 +9,6 @@ interface ITodoCardProps {
 
 const TodoCard = ({ todoList }: ITodoCardProps) => {
   const [todos, setTodos] = useState(todoList);
-  console.log('todos다!!!!', todos)
 
   const handleCheckboxChange = (scheduleId: number) => {
     const updatedTodos = todos.map((todo) => (todo.scheduleId === scheduleId ? { ...todo, active: !todo.isActive } : todo));

--- a/front/app/components/profile/MateProfile.tsx
+++ b/front/app/components/profile/MateProfile.tsx
@@ -22,8 +22,8 @@ const MateProfile = ({ isClicked, onClick, mate, size }: IMateProfileProps) => {
         {isClicked && <Image src='/svgs/mate_check.svg' alt='mate-check' width={20} height={20} />}
       </ProfileContainer>
       <Info size={size}>
-        <NickName>{mate.nickname}</NickName>
-        <Name>{mate.role}</Name>
+        <NickName>{mate.nickName}</NickName>
+        <Name>{mate.userRole}</Name>
       </Info>
     </Wrapper>
   );

--- a/front/app/components/schedule/FullCalendar.tsx
+++ b/front/app/components/schedule/FullCalendar.tsx
@@ -77,37 +77,44 @@ const Calendar = ({ selectedDate, onDateChange }: ICalendarProps) => {
     );
   };
 
+  // const handleDateClick = async (clickedDate: Date) => {
+  //   try {
+  //     const formattedDate = clickedDate.toISOString().split('T')[0];
+  //     console.log('clickedDate', clickedDate)
+  //     console.log('formattedDate', formattedDate)
+  //     const activeScheduleItem = scheduleData?.find((item) => item.scheduleDate === formattedDate && item.isActive);
+  //     console.log('activeScheduleItem임당', activeScheduleItem)
+  //     const inactiveScheduleItem = scheduleData?.find((item) => item.scheduleDate === formattedDate && !item.isActive);
+
+  //     console.log('activeScheduleItem:', activeScheduleItem)
+  //     if (activeScheduleItem) {
+  //       const response = await fetch(`/api/schedules/${activeScheduleItem.scheduleId}`);
+  //       const data = await response.json();
+  //       console.log('단일 데이터', data)
+  //       setSelectedDateTasks(data);
+  //     } else if (inactiveScheduleItem) {
+  //       setSelectedDateTasks([]);
+  //     }
+
+  //     // weekcalendar와 fullcalendar모두 상태 동일하게 업데이트
+  //     setDate(clickedDate);
+  //     onDateChange(clickedDate);
+  //   } catch (error) {
+  //     console.error('특정 날짜 스케줄 목록 조회 에러', error);
+  //   }
+  // };
+
+
   const handleDateClick = async (clickedDate: Date) => {
     try {
-      const formattedDate = clickedDate.toISOString().split('T')[0];
-      console.log('clickedDate', clickedDate)
-      console.log('formattedDate', formattedDate)
-      const activeScheduleItem = scheduleData?.find((item) => item.scheduleDate === formattedDate && item.isActive);
-      console.log('activeScheduleItem임당', activeScheduleItem)
-      const inactiveScheduleItem = scheduleData?.find((item) => item.scheduleDate === formattedDate && !item.isActive);
+      const year = getYear(clickedDate);
+      const month = getMonth(clickedDate) + 1;
+      const day = clickedDate.getDate();
+      const response = await instance.get(`/api/schedules?year=${year}&month=${month}&day=${day}`);
+      const DayData = response.data.data;
+      console.log('날짜별 데이터', DayData)
 
-      // const activeScheduleItem = scheduleData?.schedule
-      //   .map((item) => item.scheduleDate === formattedDate && item.isActive ? item : null)
-      //   .filter(item => item !== null);
-
-      // console.log('activeScheduleItem!!!!!!!', activeScheduleItem)
-      // const inactiveScheduleItem = scheduleData?.schedule
-      //   .map((item) => item.scheduleDate === formattedDate && !item.isActive ? item : null)
-      //   .filter(item => item !== null);
-
-
-
-      console.log('activeScheduleItem:', activeScheduleItem)
-      if (activeScheduleItem) {
-        const response = await fetch(`/api/schedules/${activeScheduleItem.scheduleId}`);
-        const data = await response.json();
-        console.log('단일 데이터', data)
-        setSelectedDateTasks(data);
-      } else if (inactiveScheduleItem) {
-        setSelectedDateTasks([]);
-      }
-
-      // weekcalendar와 fullcalendar모두 상태 동일하게 업데이트
+      setSelectedDateTasks(DayData);
       setDate(clickedDate);
       onDateChange(clickedDate);
     } catch (error) {

--- a/front/app/components/schedule/FullCalendar.tsx
+++ b/front/app/components/schedule/FullCalendar.tsx
@@ -32,8 +32,6 @@ const MONTHS = ['1월', '2월', '3월', '4월', '5월', '6월', '7월', '8월', 
 const Calendar = ({ selectedDate, onDateChange }: ICalendarProps) => {
   const [date, setDate] = useState(new Date());
   const [scheduleData, setScheduleData] = useState<IScheduleItem[]>([]);
-
-  console.log('scheduleData임당', scheduleData)
   const [selectedDateTasks, setSelectedDateTasks] = useState<IScheduleItem[]>([]);
   const [markedDates, setMarkedDates] = useState<Date[]>([new Date('2023-12-01'), new Date('2023-12-05'), new Date('2023-12-10')]);
   const month = getMonth(date) + 1;
@@ -77,34 +75,6 @@ const Calendar = ({ selectedDate, onDateChange }: ICalendarProps) => {
     );
   };
 
-  // const handleDateClick = async (clickedDate: Date) => {
-  //   try {
-  //     const formattedDate = clickedDate.toISOString().split('T')[0];
-  //     console.log('clickedDate', clickedDate)
-  //     console.log('formattedDate', formattedDate)
-  //     const activeScheduleItem = scheduleData?.find((item) => item.scheduleDate === formattedDate && item.isActive);
-  //     console.log('activeScheduleItem임당', activeScheduleItem)
-  //     const inactiveScheduleItem = scheduleData?.find((item) => item.scheduleDate === formattedDate && !item.isActive);
-
-  //     console.log('activeScheduleItem:', activeScheduleItem)
-  //     if (activeScheduleItem) {
-  //       const response = await fetch(`/api/schedules/${activeScheduleItem.scheduleId}`);
-  //       const data = await response.json();
-  //       console.log('단일 데이터', data)
-  //       setSelectedDateTasks(data);
-  //     } else if (inactiveScheduleItem) {
-  //       setSelectedDateTasks([]);
-  //     }
-
-  //     // weekcalendar와 fullcalendar모두 상태 동일하게 업데이트
-  //     setDate(clickedDate);
-  //     onDateChange(clickedDate);
-  //   } catch (error) {
-  //     console.error('특정 날짜 스케줄 목록 조회 에러', error);
-  //   }
-  // };
-
-
   const handleDateClick = async (clickedDate: Date) => {
     try {
       const year = getYear(clickedDate);
@@ -112,7 +82,6 @@ const Calendar = ({ selectedDate, onDateChange }: ICalendarProps) => {
       const day = clickedDate.getDate();
       const response = await instance.get(`/api/schedules?year=${year}&month=${month}&day=${day}`);
       const DayData = response.data.data;
-      console.log('날짜별 데이터', DayData)
 
       setSelectedDateTasks(DayData);
       setDate(clickedDate);

--- a/front/app/components/schedule/WeekCalendar.tsx
+++ b/front/app/components/schedule/WeekCalendar.tsx
@@ -5,37 +5,40 @@ import { addDays, format, getMonth, getYear, subDays } from 'date-fns';
 const KOREAN_DAY_NAMES = ['일', '월', '화', '수', '목', '금', '토'];
 
 interface WeekCalendarProps {
-    date: Date;
-    handleDateClick: (day: Date) => void;
+  date: Date;
+  handleDateClick: (day: Date) => void;
 }
 
 const WeekCalendar = ({ date, handleDateClick }: WeekCalendarProps) => {
-    const startOfWeek = subDays(date, date.getDay());
+  const startOfWeek = subDays(date, date.getDay());
+  console.log('startOfWeek', startOfWeek)
 
-    return (
-        <Container>
-            <Month>
-                <span>{getMonth(date) + 1}월</span>
-            </Month>
-            <DayWrapper>
-                {Array.from({ length: 7 }).map((_, index) => {
-                    const day = addDays(startOfWeek, index);
-                    const dayOfWeek = KOREAN_DAY_NAMES[index];
+  return (
+    <Container>
+      <Month>
+        <span>{getMonth(date) + 1}월</span>
+      </Month>
+      <DayWrapper>
+        {Array.from({ length: 7 }).map((_, index) => {
+          const day = addDays(startOfWeek, index);
+          console.log('day', day)
 
-                    return (
-                        <Day
-                            key={index}
-                            onClick={() => handleDateClick(day)}
-                            className={`weekDay ${format(day, 'd') === format(date, 'd') ? 'selectedDay' : ''}`}
-                        >
-                            <div className='dayOfWeek'>{dayOfWeek}</div>
-                            {format(day, 'd')}
-                        </Day>
-                    );
-                })}
-            </DayWrapper>
-        </Container>
-    );
+          const dayOfWeek = KOREAN_DAY_NAMES[index];
+
+          return (
+            <Day
+              key={index}
+              onClick={() => handleDateClick(day)}
+              className={`weekDay ${format(day, 'd') === format(date, 'd') ? 'selectedDay' : ''}`}
+            >
+              <div className='dayOfWeek'>{dayOfWeek}</div>
+              {format(day, 'd')}
+            </Day>
+          );
+        })}
+      </DayWrapper>
+    </Container>
+  );
 };
 
 const Container = styled.div`


### PR DESCRIPTION
## ✅ Changes Made
- 구현/변경한 내용 설명

## 🙋🏻‍ Review Point
- 아직 완료 여부 api 가 완성되지 않아서 UI상으로는 모두 완료 체크표시로 보이는 점 참고부탁드립니다. 
- 스케줄 '활동 유형'이 TodoCard에 scheduleType(ex.FOOD)으로 표시됩니다. 요거 이넘이나 배열로 수정해서 한글로 활동유형이 보일 수 있게 수정 예정입니다. 
- 홈페이지 UI도 반응형으로 완성해야 할 부분이 있습니다. 
- 전체적으로 세세한 UI와 반응형이 아직 완성되지 않았습니다. 이 모든 부분은 따로 브랜치 파서 pr날리겠습니다. 

## 📸 Screenshot
> 
<img width="402" alt="스크린샷 2024-06-11 오후 11 01 23" src="https://github.com/haru-puppy2024/haru-puppy-frontend/assets/76501504/38141e84-f991-4d70-abad-8b7bfa0b1d7a">

## 🙋🏻‍♀️ Question
> 스케줄 추가할 때 '반복'을 없음으로 할 때만 스케줄 api요청이 성공하지만 그 외에 반복 옵션을 설정하면 생성 실패로 뜨네요.. 왜그럴까욥.. 곰곰님도 한번 체크 부탁드려요옹
## 🔗 Reference
Issue #27 