### PR TITLE
fix: useSearchParams CSR 훅 사용 시 Suspense로 감싸도록 fix

### DIFF
--- a/front/app/(route)/auth/register/user/page.tsx
+++ b/front/app/(route)/auth/register/user/page.tsx
@@ -1,4 +1,8 @@
 'use client';
+import { Suspense, useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useRecoilValue } from 'recoil';
+import styled from 'styled-components';
 import { userState } from '@/app/_states/userState';
 import { IUser } from '@/app/_types';
 import { usePostInviteRegisterAPI } from '@/app/_utils/apis/user/usePostRegisterAPI';
@@ -9,10 +13,6 @@ import TopNavigation from '@/app/components/navigation/TopNavigation';
 import ProfileImg from '@/app/components/profile/ProfileImg';
 import RoleDropdown from '@/app/components/profile/RoleDropdown';
 import { getUserRoleSvgPath, UserRoleValue } from '@/app/constants/userRoleOptions';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, useState } from 'react';
-import { useRecoilValue } from 'recoil';
-import styled from 'styled-components';
 
 const UserRegisterPage = () => {
   const searchParams = useSearchParams();
@@ -73,14 +73,16 @@ const UserRegisterPage = () => {
   return (
     <ContainerLayout>
       <TopNavigation />
-      <UserProfileFormWrap>
-        <ProfileImg onValueChange={(value) => handleSignupForm('imgUrl', value)} imgUrl={formData.imgUrl} />
-        <Input inputType={InputType.NickName} onInputValue={(value) => handleSignupForm('nickName', value)} />
-        <RoleDropdown onValueChange={(value) => handleSignupForm('userRole', value)} />
-        <Button onClick={handleSubmit} disabled={isFormIncomplete}>
-          가입하기
-        </Button>
-      </UserProfileFormWrap>
+      <Suspense fallback={<div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100vh' }}>Loading...</div>}>
+        <UserProfileFormWrap>
+          <ProfileImg onValueChange={(value) => handleSignupForm('imgUrl', value)} imgUrl={formData.imgUrl} />
+          <Input inputType={InputType.NickName} onInputValue={(value) => handleSignupForm('nickName', value)} />
+          <RoleDropdown onValueChange={(value) => handleSignupForm('userRole', value)} />
+          <Button onClick={handleSubmit} disabled={isFormIncomplete}>
+            가입하기
+          </Button>
+        </UserProfileFormWrap>
+      </Suspense>
     </ContainerLayout>
   );
 };


### PR DESCRIPTION
## ✅ Changes Made
- useSearchParams (CSR 훅) 사용할 때 Suspense로 감싸서 데이터 로드 중에 보여줄 로딩 스피너 지정
- /profile/dog에서 클라이언트에서 로컬스토리지 확인하도록 코드 수정
- 
## 🙋🏻‍ Review Point
- 리뷰어가 확인해야 할 사항 코멘트

## 📸 Screenshot
> 스크린 샷 첨부(테스트, DB 화면 캡쳐 등)

## 🙋🏻‍♀️ Question
> 의논할 사항

## 🔗 Reference
Issue #이슈번호