### PR TITLE
fix: KakaoCallbackPage에서 isClient에 따라 useEffect로 클라이언트 렌더링

### DIFF
--- a/front/app/(route)/auth/callback/kakao/page.tsx
+++ b/front/app/(route)/auth/callback/kakao/page.tsx
@@ -8,13 +8,17 @@ import Loading from '@/app/components/loading/loading';
 
 const KakaoCallbackPage = () => {
   const [isClient, setIsClient] = useState(false);
-  const code = useCode();
+  const [code, setCode] = useState<string | null>(null);
   const [error, setError] = useState<string>();
-  const { isLoading } = useLoginQuery(code);
 
   useEffect(() => {
-    setIsClient(true);
-  }, []);
+    if (isClient) {
+      const codeFromHook = useCode();
+      setCode(codeFromHook);
+    }
+  }, [isClient]);
+
+  const { isLoading } = useLoginQuery(code);
 
   if (!isClient) {
     return null;


### PR DESCRIPTION
## ✅ Changes Made
- KakaoCallbackPage에서 useState로 code 관리
-  isClient에 따라 useEffect로 클라이언트 렌더링

## 🙋🏻‍ Review Point
- 리뷰어가 확인해야 할 사항 코멘트

## 📸 Screenshot
> 스크린 샷 첨부(테스트, DB 화면 캡쳐 등)

## 🙋🏻‍♀️ Question
> 의논할 사항

## 🔗 Reference
Issue #40 