### PR TITLE
fix: useSearchParams를 useEffect 안에서 정의하도로 fix

### DIFF
--- a/front/app/(route)/auth/login/page.tsx
+++ b/front/app/(route)/auth/login/page.tsx
@@ -1,21 +1,20 @@
 'use client';
 import { Suspense, useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Image from 'next/image';
+import { useRecoilState } from 'recoil';
+import styled from 'styled-components';
 import { userState } from '@/app/_states/userState';
 import ContainerLayout from '@/app/components/layout/layout';
 import { KAKAO_AUTH_URL } from '@/app/constants/api';
 import LogoImg from '@/public/svgs/logo.svg';
 import kakaoMsgIcon from '@/public/svgs/message-circle.svg';
-import Image from 'next/image';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useRecoilState } from 'recoil';
-import styled from 'styled-components';
 import Loading from '@/app/components/loading/loading';
 
 const LoginPage = () => {
   const [isClient, setIsClient] = useState(false);
   const [, setUserData] = useRecoilState(userState);
   const router = useRouter();
-  const params = useSearchParams();
 
   useEffect(() => {
     setIsClient(true);
@@ -26,14 +25,17 @@ const LoginPage = () => {
   }
 
   useEffect(() => {
-    const homeId = params?.get('homeId') || null;
-    if (homeId) {
-      setUserData((prevUserData) => ({
-        ...prevUserData,
-        homeId: homeId,
-      }));
+    if (isClient) {
+      const searchParams = useSearchParams();
+      const homeId = searchParams.get('homeId') || null;
+      if (homeId) {
+        setUserData((prevUserData) => ({
+          ...prevUserData,
+          homeId: homeId,
+        }));
+      }
     }
-  }, [setUserData, params]);
+  }, [isClient, setUserData]);
 
   const onLoginClick = () => {
     router.push(KAKAO_AUTH_URL);

--- a/front/app/(route)/auth/register/user/page.tsx
+++ b/front/app/(route)/auth/register/user/page.tsx
@@ -16,11 +16,10 @@ import { getUserRoleSvgPath, UserRoleValue } from '@/app/constants/userRoleOptio
 import Loading from '@/app/components/loading/loading';
 
 const UserRegisterPage = () => {
-  const searchParams = useSearchParams();
+  const [isClient, setIsClient] = useState(false);
   const router = useRouter();
   const userData = useRecoilValue(userState);
   const isInvitedUser = userData.homeId !== '';
-  const [isClient, setIsClient] = useState(false);
 
   const { mutate: inviteRegisterAPI } = usePostInviteRegisterAPI();
 
@@ -36,13 +35,14 @@ const UserRegisterPage = () => {
   }, []);
 
   useEffect(() => {
-    if (isClient && searchParams) {
-      const email = searchParams.get('email');
-      if (email) {
-        setFormData((prevFormData) => ({ ...prevFormData, email }));
+    if (isClient) {
+      const searchParams = useSearchParams();
+      const emailParam = searchParams.get('email');
+      if (emailParam) {
+        setFormData((prevFormData) => ({ ...prevFormData, email: emailParam }));
       }
     }
-  }, [isClient, searchParams]);
+  }, [isClient]);
 
   const [isFormIncomplete, setIsFormIncomplete] = useState(true);
   //1. 디폴트 이미지인지..?


### PR DESCRIPTION
## ✅ Changes Made
- useEffect로 isClient를 확인하고 있음에도 여전히 useSearchParams이 서버사이드 렌더링이 되어서 useSearchParams를 useEffect 안에서 정의하도로 fix

## 🙋🏻‍ Review Point
- 리뷰어가 확인해야 할 사항 코멘트

## 📸 Screenshot
> 스크린 샷 첨부(테스트, DB 화면 캡쳐 등)

## 🙋🏻‍♀️ Question
> 의논할 사항

## 🔗 Reference
Issue #40