### PR TITLE
chore: 카카오 리다이렉트 페이지 및 초대링크 페이지 배포용 도메인으로 교체

### DIFF
--- a/front/app/(route)/invite/page.tsx
+++ b/front/app/(route)/invite/page.tsx
@@ -31,7 +31,7 @@ const InvitePage = () => {
   };
 
   const shareLink = () => {
-    const inviteUrl = `http://localhost:3000/auth/login?homeId=${homeId}`;
+    const inviteUrl = `http://haru-puppy-frontend.vercel.app/auth/login?homeId=${homeId}`;
     copyToClipboard(inviteUrl);
   };
 

--- a/front/app/constants/api.ts
+++ b/front/app/constants/api.ts
@@ -11,7 +11,7 @@ export const BACKEND_REDIRECT_URL = 'https://port-0-haru-puppy-backend-1cupyg2kl
 
 const KAKAO_REST_API_KEY = process.env.NEXT_PUBLIC_REST_API_KEY;
 
-export const KAKAO_REDIRECT_URL = 'http://localhost:3000/auth/callback/kakao';
+export const KAKAO_REDIRECT_URL = 'http://haru-puppy-frontend.vercel.app/auth/callback/kakao';
 // export const KAKAO_REDIRECT_URL = 'https://haru-puppy-front.vercel.app/auth/callback/kakao';
 
 export const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_REST_API_KEY}&redirect_uri=${KAKAO_REDIRECT_URL}&response_type=code`;


### PR DESCRIPTION
## ✅ Changes Made
- 카카오 리다이렉트 페이지 및 초대링크 페이지 배포용 도메인으로 교체

## 🙋🏻‍ Review Point
- 리뷰어가 확인해야 할 사항 코멘트

## 📸 Screenshot
> 스크린 샷 첨부(테스트, DB 화면 캡쳐 등)

## 🙋🏻‍♀️ Question
> 의논할 사항

## 🔗 Reference
Issue #40